### PR TITLE
Enable credential requests with headers

### DIFF
--- a/packages/rif-id-core/package-lock.json
+++ b/packages/rif-id-core/package-lock.json
@@ -23,70 +23,6 @@
         "reselect": "^4.0.0"
       }
     },
-    "@rsksmart/ethr-did": {
-      "version": "1.1.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/ethr-did/-/ethr-did-1.1.1-beta.1.tgz",
-      "integrity": "sha512-7XUR0Xagxc1q9a6z+7Suo8Grno5vZVlkcS04pPO15wgBQ+O4JDaRIAOlxg3fpSFJiiOMxQyIgEEbph9dqJRBuw==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "buffer": "^5.4.3",
-        "did-jwt": "^3.0.0",
-        "did-resolver": "^1.0.0",
-        "ethjs-contract": "^0.1.9",
-        "ethjs-provider-http": "^0.1.6",
-        "ethjs-query": "^0.3.8",
-        "ethr-did-resolver": "^1.0.2"
-      },
-      "dependencies": {
-        "@stablelib/utf8": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-0.10.1.tgz",
-          "integrity": "sha512-+uM1YZ4MhBC82vt99prF7DXNGqhYmJ9cQ3p5qNowMNkkzn9OWEkqBvguBW3ChAt7JvqZ3SD5HJOfc6YgnfMTHw=="
-        },
-        "did-jwt": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-3.0.0.tgz",
-          "integrity": "sha512-/zHwoUN6eA+zTpV4HjTVMrVXOGfcfh8le4s9ibvv53ammMwdPj3RnLpw539JtnHm7dCXLq7rpjBkoX3lbbxoPQ==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "@stablelib/utf8": "^0.10.1",
-            "buffer": "^5.2.1",
-            "did-resolver": "^1.0.0",
-            "elliptic": "^6.4.0",
-            "js-sha256": "^0.9.0",
-            "js-sha3": "^0.8.0",
-            "tweetnacl": "^1.0.1",
-            "uport-base64url": "3.0.2-alpha.0"
-          }
-        },
-        "did-resolver": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
-          "integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA=="
-        },
-        "ethr-did-resolver": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-1.0.3.tgz",
-          "integrity": "sha512-9XtaB+4Ozc4W0gWHZ4J2HA+c+M7r0xcktmQI6v3GMjFto7b42Mq9zhh24kAxCqmtkqQhmUDJeqqSOIOwHrNbmQ==",
-          "requires": {
-            "buffer": "^5.1.0",
-            "did-resolver": "1.0.0",
-            "ethjs-abi": "^0.2.1",
-            "ethjs-contract": "^0.1.9",
-            "ethjs-provider-http": "^0.1.6",
-            "ethjs-query": "^0.3.5",
-            "ethr-did-registry": "^0.0.3"
-          },
-          "dependencies": {
-            "did-resolver": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.0.0.tgz",
-              "integrity": "sha512-mgJG0oqlkG7jfRzW0yN9qKawp24M4thGFdfIaZI30SAJXhpkkjqbkRxqMZLJNwqXEM0cqFbXaiFDqnd9Q1UUaw=="
-            }
-          }
-        }
-      }
-    },
     "@rsksmart/ethr-did-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rsksmart/ethr-did-utils/-/ethr-did-utils-1.0.1.tgz",
@@ -95,47 +31,6 @@
       "requires": {
         "ethjs": "^0.4.0",
         "ethr-did-registry": "0.0.3"
-      }
-    },
-    "@rsksmart/rif-id-daf": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-daf/-/rif-id-daf-0.0.5.tgz",
-      "integrity": "sha512-0fUL2HyFVg9oQ0NdTZnq9bK3upCSh44QfQV2FeAxwEguQvwGzWA//8KYNzrCQjnf5qQyJrTHtsOSlfKmd5QM/w==",
-      "requires": {
-        "@rsksmart/rif-id-ethr-did": "0.0.2",
-        "@rsksmart/rif-id-mnemonic": "0.0.1",
-        "daf-core": "^6.1.2",
-        "daf-ethr-did": "^6.1.2",
-        "typeorm": "0.2.24"
-      }
-    },
-    "@rsksmart/rif-id-ethr-did": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-ethr-did/-/rif-id-ethr-did-0.0.2.tgz",
-      "integrity": "sha512-oFVFBUzl7PrP5NDYmj771mjdxywV+o3rX6oe7Ogs3pPwkDBEBi4+9Wwv2lYzTRxoW1THzRbj6QYFKwwPNd04xA==",
-      "requires": {
-        "@rsksmart/ethr-did": "^1.1.1-beta.1",
-        "@types/elliptic": "^6.4.12",
-        "@types/keccak": "^3.0.1",
-        "@types/lodash": "^4.14.157",
-        "@types/node": "^14.0.23",
-        "elliptic": "^6.5.3",
-        "keccak": "^3.0.0",
-        "lodash": "^4.17.19",
-        "rskjs-util": "^1.0.3"
-      }
-    },
-    "@rsksmart/rif-id-mnemonic": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-mnemonic/-/rif-id-mnemonic-0.0.1.tgz",
-      "integrity": "sha512-8r9Qb+YTsXMNcoKA3Ki4dDy7emdUa5Ekx89Zv/zPjdEb0gVlajJFHvac75GLVWGtSrzz57bbiNpIRSFZqlF38Q==",
-      "requires": {
-        "@types/lodash": "^4.14.155",
-        "@types/randombytes": "^2.0.0",
-        "bip32": "^2.0.5",
-        "bip39": "^3.0.2",
-        "lodash": "^4.17.15",
-        "randombytes": "^2.1.0"
       }
     },
     "@stablelib/binary": {
@@ -195,14 +90,6 @@
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
       "integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
     },
-    "@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -225,14 +112,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/elliptic": {
-      "version": "6.4.12",
-      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
-      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
-      "requires": {
-        "@types/bn.js": "*"
       }
     },
     "@types/express": {
@@ -258,19 +137,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-/MxAVmtyyeOvZ6dGf3ciLwFRuV5M8DRIyYNFGHYI6UyBW4/XqyO0LZw+JFMvaeY3cHItQAkELclBU1x5ank6mg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/lodash": {
-      "version": "4.14.161",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA=="
-    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -280,21 +146,14 @@
     "@types/node": {
       "version": "14.10.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.2.tgz",
-      "integrity": "sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw=="
+      "integrity": "sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw==",
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
       "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
       "dev": true
-    },
-    "@types/randombytes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.0.tgz",
-      "integrity": "sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -367,29 +226,11 @@
         "follow-redirects": "^1.10.0"
       }
     },
-    "babel-plugin-module-resolver": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-      "requires": {
-        "find-babel-config": "^1.1.0",
-        "glob": "^7.1.2",
-        "pkg-up": "^2.0.0",
-        "reselect": "^3.0.1",
-        "resolve": "^1.4.0"
-      },
-      "dependencies": {
-        "reselect": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-          "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
-        }
-      }
-    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -398,7 +239,8 @@
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
         }
       }
     },
@@ -413,70 +255,10 @@
       "integrity": "sha1-hdPnAlEHVmGTM4j4MdHri49jFOM=",
       "dev": true
     },
-    "base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-    },
-    "base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip32": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.5.tgz",
-      "integrity": "sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==",
-      "requires": {
-        "@types/node": "10.12.18",
-        "bs58check": "^2.1.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "tiny-secp256k1": "^1.1.3",
-        "typeforce": "^1.11.5",
-        "wif": "^2.0.6"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.12.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
-        }
-      }
-    },
-    "bip39": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
-      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
-      "requires": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "11.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-        }
-      }
     },
     "blakejs": {
       "version": "1.1.0",
@@ -537,24 +319,6 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "buffer": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -583,15 +347,6 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      }
-    },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "cli-highlight": {
@@ -737,32 +492,8 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.0.5",
@@ -780,9 +511,9 @@
       }
     },
     "daf-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/daf-core/-/daf-core-6.1.2.tgz",
-      "integrity": "sha512-2uCYhbc2zR/LCk8DY/mc3H/p51K9wCzV15h/icmjqhRVRigoxEpnB+MDcWzwdwfFlbaaHH3ZWOKE3rI4t+WyEg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/daf-core/-/daf-core-6.3.0.tgz",
+      "integrity": "sha512-CZfpGs27OErWMCGTNA3SCBMDvExnAtrHD591iZenusztXKBdLjO/L7Y5y/akoQGH+drTt0WPN7bzpI6/jcx/1A==",
       "requires": {
         "blakejs": "^1.1.0",
         "debug": "^4.1.1",
@@ -855,32 +586,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
           "integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA=="
-        }
-      }
-    },
-    "daf-ethr-did": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/daf-ethr-did/-/daf-ethr-did-6.3.0.tgz",
-      "integrity": "sha512-2vMjmvYa0ZxbgRQzAmaBV4fSgr30QH+ftnnODbdxcqWFC0asxysZJcSvHwJMfrYsjrsqVv99gtrTkB7cXx4e+A==",
-      "requires": {
-        "daf-core": "^6.3.0",
-        "debug": "^4.1.1",
-        "ethjs-provider-signer": "^0.1.4",
-        "ethr-did": "^1.1.0",
-        "js-sha3": "^0.8.0"
-      },
-      "dependencies": {
-        "daf-core": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/daf-core/-/daf-core-6.3.0.tgz",
-          "integrity": "sha512-CZfpGs27OErWMCGTNA3SCBMDvExnAtrHD591iZenusztXKBdLjO/L7Y5y/akoQGH+drTt0WPN7bzpI6/jcx/1A==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "debug": "^4.1.1",
-            "events": "^3.0.0",
-            "typeorm": "^0.2.24",
-            "uuid": "^7.0.2"
-          }
         }
       }
     },
@@ -1178,6 +883,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
       "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
+      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "js-sha3": "0.5.5",
@@ -1187,17 +893,20 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
         },
         "js-sha3": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
         },
         "number-to-bn": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -1209,6 +918,7 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/ethjs-contract/-/ethjs-contract-0.1.9.tgz",
       "integrity": "sha1-HCdmiWpW1H7B1tZhgpxJzDilUgo=",
+      "dev": true,
       "requires": {
         "ethjs-abi": "0.2.0",
         "ethjs-filter": "0.1.5",
@@ -1219,12 +929,14 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
         },
         "ethjs-abi": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.0.tgz",
           "integrity": "sha1-0+LCIQEVIPxJm3FoIDbBT8wvWyU=",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "js-sha3": "0.5.5",
@@ -1234,12 +946,14 @@
         "js-sha3": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
         },
         "number-to-bn": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -1250,12 +964,14 @@
     "ethjs-filter": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/ethjs-filter/-/ethjs-filter-0.1.5.tgz",
-      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg="
+      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg=",
+      "dev": true
     },
     "ethjs-format": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.2.7.tgz",
       "integrity": "sha512-uNYAi+r3/mvR3xYu2AfSXx5teP4ovy9z2FrRsblU+h2logsaIKZPi9V3bn3V7wuRcnG0HZ3QydgZuVaRo06C4Q==",
+      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "ethjs-schema": "0.2.1",
@@ -1268,12 +984,14 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
         },
         "number-to-bn": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -1285,65 +1003,16 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-provider-http/-/ethjs-provider-http-0.1.6.tgz",
       "integrity": "sha1-HsXZtL4lfvHValALIqdBmF6IlCA=",
+      "dev": true,
       "requires": {
         "xhr2": "0.1.3"
-      }
-    },
-    "ethjs-provider-signer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/ethjs-provider-signer/-/ethjs-provider-signer-0.1.4.tgz",
-      "integrity": "sha1-a9XLOKjVsN30asHiOmDuoXFhca4=",
-      "requires": {
-        "ethjs-provider-http": "0.1.6",
-        "ethjs-rpc": "0.1.2"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "ethjs-format": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.1.8.tgz",
-          "integrity": "sha1-kl7N2WXqcqKi2vKhIuW/gLWtUio=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "ethjs-schema": "0.1.4",
-            "ethjs-util": "0.1.3",
-            "is-hex-prefixed": "1.0.0",
-            "number-to-bn": "1.7.0",
-            "strip-hex-prefix": "1.0.0"
-          }
-        },
-        "ethjs-rpc": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.1.2.tgz",
-          "integrity": "sha1-OaNFa1HFmu6vtbpVZYmlny2ojSY=",
-          "requires": {
-            "ethjs-format": "0.1.8"
-          }
-        },
-        "ethjs-schema": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.1.4.tgz",
-          "integrity": "sha1-AyOhYzOxrOmo8daWpu5jRI/dRV8="
-        },
-        "number-to-bn": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-          "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-          "requires": {
-            "bn.js": "4.11.6",
-            "strip-hex-prefix": "1.0.0"
-          }
-        }
       }
     },
     "ethjs-query": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/ethjs-query/-/ethjs-query-0.3.8.tgz",
       "integrity": "sha512-/J5JydqrOzU8O7VBOwZKUWXxHDGr46VqNjBCJgBVNNda+tv7Xc8Y2uJc6aMHHVbeN3YOQ7YRElgIc0q1CI02lQ==",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "ethjs-format": "0.2.7",
@@ -1355,6 +1024,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.2.0.tgz",
       "integrity": "sha512-RINulkNZTKnj4R/cjYYtYMnFFaBcVALzbtEJEONrrka8IeoarNB9Jbzn+2rT00Cv8y/CxAI+GgY1d0/i2iQeOg==",
+      "dev": true,
       "requires": {
         "promise-to-callback": "^1.0.0"
       }
@@ -1362,7 +1032,8 @@
     "ethjs-schema": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.2.1.tgz",
-      "integrity": "sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g=="
+      "integrity": "sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g==",
+      "dev": true
     },
     "ethjs-signer": {
       "version": "0.1.1",
@@ -1429,69 +1100,17 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
       "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
+      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
       }
     },
-    "ethr-did": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ethr-did/-/ethr-did-1.1.0.tgz",
-      "integrity": "sha512-sk5Q7mM+zC8IpffQaWXyCLZLSVMoasgpZJXZ++7ONslGEJQfs1fcvqvXZ5zLoHqYjVud9I8LpXTgbpGJsONY+A==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "buffer": "^5.1.0",
-        "did-jwt": "^0.1.1",
-        "did-resolver": "^0.0.6",
-        "ethjs-contract": "^0.1.9",
-        "ethjs-provider-http": "^0.1.6",
-        "ethjs-query": "^0.3.8",
-        "ethr-did-resolver": "^0.2.0"
-      },
-      "dependencies": {
-        "did-jwt": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-0.1.3.tgz",
-          "integrity": "sha512-hZvjC4bstxo6bqFIOAlX90LdSaA5uxMdg0zSFCPm2WwIhgHFp4SfVM6f5yq1ebA5/cJzcUr+MclnTrlEiixuiQ==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "base64url": "^3.0.1",
-            "buffer": "^5.2.1",
-            "did-resolver": "0.0.6",
-            "elliptic": "^6.4.0",
-            "js-sha256": "^0.9.0",
-            "js-sha3": "^0.8.0",
-            "tweetnacl": "^1.0.1",
-            "tweetnacl-util": "^0.15.0"
-          }
-        },
-        "did-resolver": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-0.0.6.tgz",
-          "integrity": "sha512-PqxzaoomTbJG3IzEouUGgppu3xrsbGKHS75zS3vS/Hfm56XxLpwIe7yFLokgXUbMWmLa0dczFHOibmebO4wRLA=="
-        },
-        "ethr-did-resolver": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-0.2.0.tgz",
-          "integrity": "sha512-6ysQhoDa8vGFesECQfxFkEV+DVFMhcWJ35qgMVk0F8a9i7Iy9Fl29cM/5U7JCgBjZoaPrSKCMmNK4rfFNrYc4A==",
-          "requires": {
-            "babel-plugin-module-resolver": "^3.1.1",
-            "babel-runtime": "^6.26.0",
-            "buffer": "^5.1.0",
-            "did-resolver": "0.0.6",
-            "ethjs-abi": "^0.2.1",
-            "ethjs-contract": "^0.1.9",
-            "ethjs-provider-http": "^0.1.6",
-            "ethjs-query": "^0.3.5",
-            "ethr-did-registry": "^0.0.3"
-          }
-        }
-      }
-    },
     "ethr-did-registry": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/ethr-did-registry/-/ethr-did-registry-0.0.3.tgz",
-      "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw=="
+      "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw==",
+      "dev": true
     },
     "ethr-did-resolver": {
       "version": "2.2.0",
@@ -1587,11 +1206,6 @@
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.0.tgz",
       "integrity": "sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww=="
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -1621,22 +1235,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        }
-      }
-    },
-    "find-babel-config": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-      "requires": {
-        "json5": "^0.5.1",
-        "path-exists": "^3.0.0"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
       }
     },
@@ -1708,16 +1306,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
-      }
     },
     "hash.js": {
       "version": "1.1.7",
@@ -1806,7 +1394,8 @@
     "is-fn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1816,7 +1405,8 @@
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+      "dev": true
     },
     "js-sha256": {
       "version": "0.9.0",
@@ -1842,20 +1432,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-    },
-    "keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-      "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      }
-    },
     "libsodium": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
@@ -1879,27 +1455,12 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
       }
     },
     "media-typer": {
@@ -2007,26 +1568,11 @@
         }
       }
     },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
-    },
-    "node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-    },
-    "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "number-to-bn": {
       "version": "1.1.0",
@@ -2124,86 +1670,17 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
-    "pbkdf2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
-      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
-      "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-      "requires": {
-        "find-up": "^2.1.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        }
-      }
-    },
     "promise-to-callback": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
       "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
+      "dev": true,
       "requires": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
@@ -2225,14 +1702,6 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2249,16 +1718,6 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
       }
     },
     "redux": {
@@ -2300,49 +1759,11 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
       "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
-    "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "requires": {
-        "path-parse": "^1.0.6"
-      }
-    },
-    "ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
     "rlp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
       "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A=",
       "dev": true
-    },
-    "rskjs-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rskjs-util/-/rskjs-util-1.0.3.tgz",
-      "integrity": "sha512-Q6zfYFQndaBln1iY2gnBfYgDLymbZHAxKXOcZVLAKJkHilcieoUN3ZXVxLA3K30KlgAfmRVG72iTzi+yPNZB1w==",
-      "requires": {
-        "keccak": "^1.0.2"
-      },
-      "dependencies": {
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        }
-      }
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -2426,7 +1847,8 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -2464,14 +1886,6 @@
         "strip-ansi": "^6.0.0"
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -2484,6 +1898,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }
@@ -2517,18 +1932,6 @@
         "thenify": ">= 3.1.0 < 4"
       }
     },
-    "tiny-secp256k1": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
-      "requires": {
-        "bindings": "^1.3.0",
-        "bn.js": "^4.11.8",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.4.0",
-        "nan": "^2.13.2"
-      }
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -2543,12 +1946,14 @@
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true
     },
     "tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -2559,11 +1964,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
-    },
-    "typeforce": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typeorm": {
       "version": "0.2.24",
@@ -2601,11 +2001,6 @@
         "buffer": "^5.2.1"
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -2637,14 +2032,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-    },
-    "wif": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
-      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
-      "requires": {
-        "bs58check": "<3.0.0"
-      }
     },
     "wrap-ansi": {
       "version": "6.2.0",
@@ -2688,7 +2075,8 @@
     "xhr2": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
-      "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE="
+      "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE=",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.23",

--- a/packages/rif-id-core/package-lock.json
+++ b/packages/rif-id-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-id-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -23,6 +23,70 @@
         "reselect": "^4.0.0"
       }
     },
+    "@rsksmart/ethr-did": {
+      "version": "1.1.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/ethr-did/-/ethr-did-1.1.1-beta.1.tgz",
+      "integrity": "sha512-7XUR0Xagxc1q9a6z+7Suo8Grno5vZVlkcS04pPO15wgBQ+O4JDaRIAOlxg3fpSFJiiOMxQyIgEEbph9dqJRBuw==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "buffer": "^5.4.3",
+        "did-jwt": "^3.0.0",
+        "did-resolver": "^1.0.0",
+        "ethjs-contract": "^0.1.9",
+        "ethjs-provider-http": "^0.1.6",
+        "ethjs-query": "^0.3.8",
+        "ethr-did-resolver": "^1.0.2"
+      },
+      "dependencies": {
+        "@stablelib/utf8": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-0.10.1.tgz",
+          "integrity": "sha512-+uM1YZ4MhBC82vt99prF7DXNGqhYmJ9cQ3p5qNowMNkkzn9OWEkqBvguBW3ChAt7JvqZ3SD5HJOfc6YgnfMTHw=="
+        },
+        "did-jwt": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-3.0.0.tgz",
+          "integrity": "sha512-/zHwoUN6eA+zTpV4HjTVMrVXOGfcfh8le4s9ibvv53ammMwdPj3RnLpw539JtnHm7dCXLq7rpjBkoX3lbbxoPQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@stablelib/utf8": "^0.10.1",
+            "buffer": "^5.2.1",
+            "did-resolver": "^1.0.0",
+            "elliptic": "^6.4.0",
+            "js-sha256": "^0.9.0",
+            "js-sha3": "^0.8.0",
+            "tweetnacl": "^1.0.1",
+            "uport-base64url": "3.0.2-alpha.0"
+          }
+        },
+        "did-resolver": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
+          "integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA=="
+        },
+        "ethr-did-resolver": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-1.0.3.tgz",
+          "integrity": "sha512-9XtaB+4Ozc4W0gWHZ4J2HA+c+M7r0xcktmQI6v3GMjFto7b42Mq9zhh24kAxCqmtkqQhmUDJeqqSOIOwHrNbmQ==",
+          "requires": {
+            "buffer": "^5.1.0",
+            "did-resolver": "1.0.0",
+            "ethjs-abi": "^0.2.1",
+            "ethjs-contract": "^0.1.9",
+            "ethjs-provider-http": "^0.1.6",
+            "ethjs-query": "^0.3.5",
+            "ethr-did-registry": "^0.0.3"
+          },
+          "dependencies": {
+            "did-resolver": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.0.0.tgz",
+              "integrity": "sha512-mgJG0oqlkG7jfRzW0yN9qKawp24M4thGFdfIaZI30SAJXhpkkjqbkRxqMZLJNwqXEM0cqFbXaiFDqnd9Q1UUaw=="
+            }
+          }
+        }
+      }
+    },
     "@rsksmart/ethr-did-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rsksmart/ethr-did-utils/-/ethr-did-utils-1.0.1.tgz",
@@ -31,6 +95,47 @@
       "requires": {
         "ethjs": "^0.4.0",
         "ethr-did-registry": "0.0.3"
+      }
+    },
+    "@rsksmart/rif-id-daf": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-daf/-/rif-id-daf-0.0.5.tgz",
+      "integrity": "sha512-0fUL2HyFVg9oQ0NdTZnq9bK3upCSh44QfQV2FeAxwEguQvwGzWA//8KYNzrCQjnf5qQyJrTHtsOSlfKmd5QM/w==",
+      "requires": {
+        "@rsksmart/rif-id-ethr-did": "0.0.2",
+        "@rsksmart/rif-id-mnemonic": "0.0.1",
+        "daf-core": "^6.1.2",
+        "daf-ethr-did": "^6.1.2",
+        "typeorm": "0.2.24"
+      }
+    },
+    "@rsksmart/rif-id-ethr-did": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-ethr-did/-/rif-id-ethr-did-0.0.2.tgz",
+      "integrity": "sha512-oFVFBUzl7PrP5NDYmj771mjdxywV+o3rX6oe7Ogs3pPwkDBEBi4+9Wwv2lYzTRxoW1THzRbj6QYFKwwPNd04xA==",
+      "requires": {
+        "@rsksmart/ethr-did": "^1.1.1-beta.1",
+        "@types/elliptic": "^6.4.12",
+        "@types/keccak": "^3.0.1",
+        "@types/lodash": "^4.14.157",
+        "@types/node": "^14.0.23",
+        "elliptic": "^6.5.3",
+        "keccak": "^3.0.0",
+        "lodash": "^4.17.19",
+        "rskjs-util": "^1.0.3"
+      }
+    },
+    "@rsksmart/rif-id-mnemonic": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-mnemonic/-/rif-id-mnemonic-0.0.1.tgz",
+      "integrity": "sha512-8r9Qb+YTsXMNcoKA3Ki4dDy7emdUa5Ekx89Zv/zPjdEb0gVlajJFHvac75GLVWGtSrzz57bbiNpIRSFZqlF38Q==",
+      "requires": {
+        "@types/lodash": "^4.14.155",
+        "@types/randombytes": "^2.0.0",
+        "bip32": "^2.0.5",
+        "bip39": "^3.0.2",
+        "lodash": "^4.17.15",
+        "randombytes": "^2.1.0"
       }
     },
     "@stablelib/binary": {
@@ -90,6 +195,14 @@
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.0.tgz",
       "integrity": "sha512-0Fd4MQCbEh8OFSO+gG7wBXok7yRC3w+xe/wWM8KNye7EGoHr4BTFZNWV/1xAn2r8/gyFKxPXT8uxXRzDzGq6rg=="
     },
+    "@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -112,6 +225,14 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "requires": {
+        "@types/bn.js": "*"
       }
     },
     "@types/express": {
@@ -137,6 +258,19 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-/MxAVmtyyeOvZ6dGf3ciLwFRuV5M8DRIyYNFGHYI6UyBW4/XqyO0LZw+JFMvaeY3cHItQAkELclBU1x5ank6mg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.161",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA=="
+    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -146,14 +280,21 @@
     "@types/node": {
       "version": "14.10.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.2.tgz",
-      "integrity": "sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw==",
-      "dev": true
+      "integrity": "sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw=="
     },
     "@types/qs": {
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
       "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
       "dev": true
+    },
+    "@types/randombytes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.0.tgz",
+      "integrity": "sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -226,11 +367,29 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "babel-plugin-module-resolver": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
+      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
+      "requires": {
+        "find-babel-config": "^1.1.0",
+        "glob": "^7.1.2",
+        "pkg-up": "^2.0.0",
+        "reselect": "^3.0.1",
+        "resolve": "^1.4.0"
+      },
+      "dependencies": {
+        "reselect": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+          "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
+        }
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -239,8 +398,7 @@
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
     },
@@ -255,10 +413,70 @@
       "integrity": "sha1-hdPnAlEHVmGTM4j4MdHri49jFOM=",
       "dev": true
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip32": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.5.tgz",
+      "integrity": "sha512-zVY4VvJV+b2fS0/dcap/5XLlpqtgwyN8oRkuGgAS1uLOeEp0Yo6Tw2yUTozTtlrMJO3G8n4g/KX/XGFHW6Pq3g==",
+      "requires": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.1.3",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+      }
+    },
+    "bip39": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+      "requires": {
+        "@types/node": "11.11.6",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        }
+      }
     },
     "blakejs": {
       "version": "1.1.0",
@@ -319,6 +537,24 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "buffer": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -347,6 +583,15 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cli-highlight": {
@@ -492,8 +737,32 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
     },
     "cross-fetch": {
       "version": "3.0.5",
@@ -586,6 +855,32 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
           "integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA=="
+        }
+      }
+    },
+    "daf-ethr-did": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/daf-ethr-did/-/daf-ethr-did-6.3.0.tgz",
+      "integrity": "sha512-2vMjmvYa0ZxbgRQzAmaBV4fSgr30QH+ftnnODbdxcqWFC0asxysZJcSvHwJMfrYsjrsqVv99gtrTkB7cXx4e+A==",
+      "requires": {
+        "daf-core": "^6.3.0",
+        "debug": "^4.1.1",
+        "ethjs-provider-signer": "^0.1.4",
+        "ethr-did": "^1.1.0",
+        "js-sha3": "^0.8.0"
+      },
+      "dependencies": {
+        "daf-core": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/daf-core/-/daf-core-6.3.0.tgz",
+          "integrity": "sha512-CZfpGs27OErWMCGTNA3SCBMDvExnAtrHD591iZenusztXKBdLjO/L7Y5y/akoQGH+drTt0WPN7bzpI6/jcx/1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "debug": "^4.1.1",
+            "events": "^3.0.0",
+            "typeorm": "^0.2.24",
+            "uuid": "^7.0.2"
+          }
         }
       }
     },
@@ -883,7 +1178,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
       "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "js-sha3": "0.5.5",
@@ -893,20 +1187,17 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
         "js-sha3": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
-          "dev": true
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
         },
         "number-to-bn": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -918,7 +1209,6 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/ethjs-contract/-/ethjs-contract-0.1.9.tgz",
       "integrity": "sha1-HCdmiWpW1H7B1tZhgpxJzDilUgo=",
-      "dev": true,
       "requires": {
         "ethjs-abi": "0.2.0",
         "ethjs-filter": "0.1.5",
@@ -929,14 +1219,12 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
         "ethjs-abi": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.0.tgz",
           "integrity": "sha1-0+LCIQEVIPxJm3FoIDbBT8wvWyU=",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "js-sha3": "0.5.5",
@@ -946,14 +1234,12 @@
         "js-sha3": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
-          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
-          "dev": true
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
         },
         "number-to-bn": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -964,14 +1250,12 @@
     "ethjs-filter": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/ethjs-filter/-/ethjs-filter-0.1.5.tgz",
-      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg=",
-      "dev": true
+      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg="
     },
     "ethjs-format": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.2.7.tgz",
       "integrity": "sha512-uNYAi+r3/mvR3xYu2AfSXx5teP4ovy9z2FrRsblU+h2logsaIKZPi9V3bn3V7wuRcnG0HZ3QydgZuVaRo06C4Q==",
-      "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "ethjs-schema": "0.2.1",
@@ -984,14 +1268,12 @@
         "bn.js": {
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
         "number-to-bn": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-          "dev": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -1003,16 +1285,65 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-provider-http/-/ethjs-provider-http-0.1.6.tgz",
       "integrity": "sha1-HsXZtL4lfvHValALIqdBmF6IlCA=",
-      "dev": true,
       "requires": {
         "xhr2": "0.1.3"
+      }
+    },
+    "ethjs-provider-signer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ethjs-provider-signer/-/ethjs-provider-signer-0.1.4.tgz",
+      "integrity": "sha1-a9XLOKjVsN30asHiOmDuoXFhca4=",
+      "requires": {
+        "ethjs-provider-http": "0.1.6",
+        "ethjs-rpc": "0.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "ethjs-format": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.1.8.tgz",
+          "integrity": "sha1-kl7N2WXqcqKi2vKhIuW/gLWtUio=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "ethjs-schema": "0.1.4",
+            "ethjs-util": "0.1.3",
+            "is-hex-prefixed": "1.0.0",
+            "number-to-bn": "1.7.0",
+            "strip-hex-prefix": "1.0.0"
+          }
+        },
+        "ethjs-rpc": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.1.2.tgz",
+          "integrity": "sha1-OaNFa1HFmu6vtbpVZYmlny2ojSY=",
+          "requires": {
+            "ethjs-format": "0.1.8"
+          }
+        },
+        "ethjs-schema": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.1.4.tgz",
+          "integrity": "sha1-AyOhYzOxrOmo8daWpu5jRI/dRV8="
+        },
+        "number-to-bn": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+          "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "strip-hex-prefix": "1.0.0"
+          }
+        }
       }
     },
     "ethjs-query": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/ethjs-query/-/ethjs-query-0.3.8.tgz",
       "integrity": "sha512-/J5JydqrOzU8O7VBOwZKUWXxHDGr46VqNjBCJgBVNNda+tv7Xc8Y2uJc6aMHHVbeN3YOQ7YRElgIc0q1CI02lQ==",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "ethjs-format": "0.2.7",
@@ -1024,7 +1355,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.2.0.tgz",
       "integrity": "sha512-RINulkNZTKnj4R/cjYYtYMnFFaBcVALzbtEJEONrrka8IeoarNB9Jbzn+2rT00Cv8y/CxAI+GgY1d0/i2iQeOg==",
-      "dev": true,
       "requires": {
         "promise-to-callback": "^1.0.0"
       }
@@ -1032,8 +1362,7 @@
     "ethjs-schema": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.2.1.tgz",
-      "integrity": "sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g==",
-      "dev": true
+      "integrity": "sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g=="
     },
     "ethjs-signer": {
       "version": "0.1.1",
@@ -1100,17 +1429,69 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
       "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
-      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
       }
     },
+    "ethr-did": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ethr-did/-/ethr-did-1.1.0.tgz",
+      "integrity": "sha512-sk5Q7mM+zC8IpffQaWXyCLZLSVMoasgpZJXZ++7ONslGEJQfs1fcvqvXZ5zLoHqYjVud9I8LpXTgbpGJsONY+A==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "buffer": "^5.1.0",
+        "did-jwt": "^0.1.1",
+        "did-resolver": "^0.0.6",
+        "ethjs-contract": "^0.1.9",
+        "ethjs-provider-http": "^0.1.6",
+        "ethjs-query": "^0.3.8",
+        "ethr-did-resolver": "^0.2.0"
+      },
+      "dependencies": {
+        "did-jwt": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-0.1.3.tgz",
+          "integrity": "sha512-hZvjC4bstxo6bqFIOAlX90LdSaA5uxMdg0zSFCPm2WwIhgHFp4SfVM6f5yq1ebA5/cJzcUr+MclnTrlEiixuiQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "base64url": "^3.0.1",
+            "buffer": "^5.2.1",
+            "did-resolver": "0.0.6",
+            "elliptic": "^6.4.0",
+            "js-sha256": "^0.9.0",
+            "js-sha3": "^0.8.0",
+            "tweetnacl": "^1.0.1",
+            "tweetnacl-util": "^0.15.0"
+          }
+        },
+        "did-resolver": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-0.0.6.tgz",
+          "integrity": "sha512-PqxzaoomTbJG3IzEouUGgppu3xrsbGKHS75zS3vS/Hfm56XxLpwIe7yFLokgXUbMWmLa0dczFHOibmebO4wRLA=="
+        },
+        "ethr-did-resolver": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-0.2.0.tgz",
+          "integrity": "sha512-6ysQhoDa8vGFesECQfxFkEV+DVFMhcWJ35qgMVk0F8a9i7Iy9Fl29cM/5U7JCgBjZoaPrSKCMmNK4rfFNrYc4A==",
+          "requires": {
+            "babel-plugin-module-resolver": "^3.1.1",
+            "babel-runtime": "^6.26.0",
+            "buffer": "^5.1.0",
+            "did-resolver": "0.0.6",
+            "ethjs-abi": "^0.2.1",
+            "ethjs-contract": "^0.1.9",
+            "ethjs-provider-http": "^0.1.6",
+            "ethjs-query": "^0.3.5",
+            "ethr-did-registry": "^0.0.3"
+          }
+        }
+      }
+    },
     "ethr-did-registry": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/ethr-did-registry/-/ethr-did-registry-0.0.3.tgz",
-      "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw==",
-      "dev": true
+      "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw=="
     },
     "ethr-did-resolver": {
       "version": "2.2.0",
@@ -1206,6 +1587,11 @@
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.0.tgz",
       "integrity": "sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -1235,6 +1621,22 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
       }
     },
@@ -1306,6 +1708,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
     },
     "hash.js": {
       "version": "1.1.7",
@@ -1394,8 +1806,7 @@
     "is-fn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
-      "dev": true
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1405,8 +1816,7 @@
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-      "dev": true
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "js-sha256": {
       "version": "0.9.0",
@@ -1432,6 +1842,20 @@
         "esprima": "^4.0.0"
       }
     },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "libsodium": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.8.tgz",
@@ -1455,12 +1879,27 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "media-typer": {
@@ -1568,11 +2007,26 @@
         }
       }
     },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
+    },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "number-to-bn": {
       "version": "1.1.0",
@@ -1670,17 +2124,86 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
+    "pbkdf2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
+      }
+    },
     "promise-to-callback": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
       "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
-      "dev": true,
       "requires": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
@@ -1702,6 +2225,14 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1718,6 +2249,16 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "redux": {
@@ -1759,11 +2300,49 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
       "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "rlp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
       "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A=",
       "dev": true
+    },
+    "rskjs-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rskjs-util/-/rskjs-util-1.0.3.tgz",
+      "integrity": "sha512-Q6zfYFQndaBln1iY2gnBfYgDLymbZHAxKXOcZVLAKJkHilcieoUN3ZXVxLA3K30KlgAfmRVG72iTzi+yPNZB1w==",
+      "requires": {
+        "keccak": "^1.0.2"
+      },
+      "dependencies": {
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -1847,8 +2426,7 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -1886,6 +2464,14 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -1898,7 +2484,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }
@@ -1932,6 +2517,18 @@
         "thenify": ">= 3.1.0 < 4"
       }
     },
+    "tiny-secp256k1": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
+      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -1946,14 +2543,12 @@
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -1964,6 +2559,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typeorm": {
       "version": "0.2.24",
@@ -2001,6 +2601,11 @@
         "buffer": "^5.2.1"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -2032,6 +2637,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
+      }
     },
     "wrap-ansi": {
       "version": "6.2.0",
@@ -2075,8 +2688,7 @@
     "xhr2": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
-      "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE=",
-      "dev": true
+      "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE="
     },
     "xml2js": {
       "version": "0.4.23",

--- a/packages/rif-id-core/package.json
+++ b/packages/rif-id-core/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://github.com/rsksamrt/rif-identity.js#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.4.0",
-    "@rsksmart/rif-id-daf": "0.0.5",
-    "daf-core": "^6.1.2",
+    "@rsksmart/rif-id-daf": "0.0.6",
+    "daf-core": "^6.3.0",
     "daf-did-comm": "^6.3.0",
     "daf-selective-disclosure": "^6.3.0",
     "daf-w3c": "^6.3.0",

--- a/packages/rif-id-core/src/operations/credentialRequests.ts
+++ b/packages/rif-id-core/src/operations/credentialRequests.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from '@reduxjs/toolkit'
 import { Agent } from 'daf-core'
 import { SelectiveDisclosureRequest } from 'daf-selective-disclosure'
-import { ActionSendDIDComm } from 'daf-did-comm'
+import { ActionSendDIDComm } from '@rsksmart/rif-id-daf/lib/did-comm-action-handler'
 import { addIssuedCredentialRequest, Claims, IssuedCredentialRequest, setIssuedCredentialRequestStatus, deleteIssuedCredentialRequest } from '../reducers/issuedCredentialRequests'
 import { CredentialRequest, findCredentialRequests } from '../entities/CredentialRequest'
 import { callbackify, Callback } from './util'
@@ -26,7 +26,7 @@ export const initCredentialRequestsFactory = (agent: Agent) => (cb?: Callback<Is
   cb
 )
 
-export const issueCredentialRequestFactory = (agent: Agent) => (from: string, to: string, claims: Claims, status: string, url?: string, cb?: Callback<IssuedCredentialRequest>) => (dispatch: Dispatch): IssuedCredentialRequest => callbackify(
+export const issueCredentialRequestFactory = (agent: Agent) => (from: string, to: string, claims: Claims, status: string, sendOptions?: { url?: string, headers?: HeadersInit }, cb?: Callback<IssuedCredentialRequest>) => (dispatch: Dispatch): IssuedCredentialRequest => callbackify(
   () => agent.handleAction({
     type: 'sign.sdr.jwt',
     data: {
@@ -42,7 +42,7 @@ export const issueCredentialRequestFactory = (agent: Agent) => (from: string, to
       type: 'jwt',
       body: jwt
     },
-    url,
+    ...sendOptions,
     save: true
   } as ActionSendDIDComm)
   ).then(message => {

--- a/packages/rif-id-core/test/operations/credentialRequests.test.ts
+++ b/packages/rif-id-core/test/operations/credentialRequests.test.ts
@@ -61,7 +61,7 @@ describe('credential requests operations', () => {
 
     describe('issue credential request', () => {
       test('success', async () => {
-        const credentialRequest = await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, issuerServerUrl + '/request_credential')(store.dispatch)
+        const credentialRequest = await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, { url: issuerServerUrl + '/request_credential', headers: { testHeader: 'test' } })(store.dispatch)
 
         expect(credentialRequest.from).toBe(did)
         expect(credentialRequest.to).toBe(did2)
@@ -80,7 +80,7 @@ describe('credential requests operations', () => {
 
       test('fails to sign jwt when identity does not exist', async () => {
         await expect(
-          issueCredentialRequest(did3, did2, claims, defaultIssuedCredentialRequestStatus, issuerServerUrl + '/request_credential')(store.dispatch)
+          issueCredentialRequest(did3, did2, claims, defaultIssuedCredentialRequestStatus, { url: issuerServerUrl + '/request_credential' })(store.dispatch)
         ).rejects.toThrow('Identity not found')
       })
 
@@ -93,7 +93,7 @@ describe('credential requests operations', () => {
 
     describe('set issued credential request status', () => {
       test('success', async () => {
-        const credentialRequest = await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, issuerServerUrl + '/request_credential')(store.dispatch)
+        const credentialRequest = await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, { url: issuerServerUrl + '/request_credential' })(store.dispatch)
         await setIssuedCredentialRequestStatus(did, credentialRequest.id, 'received')(store.dispatch)
 
         const state = store.getState()
@@ -117,7 +117,7 @@ describe('credential requests operations', () => {
 
     describe('delete issued credential request', () => {
       test('success', async () => {
-        const credentialRequest = await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, issuerServerUrl + '/request_credential')(store.dispatch)
+        const credentialRequest = await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, { url: issuerServerUrl + '/request_credential' })(store.dispatch)
         await deleteIssuedCredentialRequest(did, credentialRequest.id)(store.dispatch)
 
         expect(store.getState()).toEqual({})
@@ -143,7 +143,7 @@ describe('credential requests operations', () => {
     })
 
     test('with issued credential request', async () => {
-      await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, issuerServerUrl + '/request_credential')(store.dispatch)
+      await issueCredentialRequest(did, did2, claims, defaultIssuedCredentialRequestStatus, { url: issuerServerUrl + '/request_credential' })(store.dispatch)
 
       await (await agent.dbConnection).close()
 

--- a/packages/rif-id-core/test/util.ts
+++ b/packages/rif-id-core/test/util.ts
@@ -1,17 +1,18 @@
 import { createConnection, Connection } from 'typeorm'
 import * as Daf from 'daf-core'
 import { SecretBox, KeyManagementSystem } from 'daf-libsodium'
-import { Entities, MnemonicStore, RIFIdKeyManagementSystem, RIFIdentityProvider } from '@rsksmart/rif-id-daf'
 import { DafResolver } from 'daf-resolver'
 import { JwtMessageHandler } from 'daf-did-jwt'
 import { W3cMessageHandler, W3cActionHandler, ActionSignW3cVc } from 'daf-w3c'
+import { DIDCommMessageHandler } from 'daf-did-comm'
+import { DIDCommActionHandler } from '@rsksmart/rif-id-daf/lib/did-comm-action-handler'
+import { SdrMessageHandler, SdrActionHandler } from 'daf-selective-disclosure'
+import { generateMnemonic } from '@rsksmart/rif-id-mnemonic'
+import { Entities, MnemonicStore, RIFIdKeyManagementSystem, RIFIdentityProvider } from '@rsksmart/rif-id-daf'
 import fs from 'fs'
 import express from 'express'
 import bodyParser from 'body-parser'
 import { DeclarativeDetail, CredentialRequest } from '../src/entities'
-import { generateMnemonic } from '@rsksmart/rif-id-mnemonic'
-import { DIDCommMessageHandler, DIDCommActionHandler } from 'daf-did-comm'
-import { SdrMessageHandler, SdrActionHandler } from 'daf-selective-disclosure'
 
 const network = 'rsk:testnet'
 
@@ -162,7 +163,7 @@ export const startTestIssuerServer = (handle: any) => {
   app.use(bodyParser.text())
 
   app.post('/request_credential', function(req, res) {
-    const jwt = req.body
+    if (!!req.headers['testHeader']) expect(req.headers['testHeader']).toEqual('test')
     res.status(200).send('')
   })
 

--- a/packages/rif-id-daf/package-lock.json
+++ b/packages/rif-id-daf/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-id-daf",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -363,6 +363,14 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "daf-core": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/daf-core/-/daf-core-6.1.2.tgz",
@@ -373,6 +381,13 @@
         "events": "^3.0.0",
         "typeorm": "^0.2.24",
         "uuid": "^7.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
       }
     },
     "daf-ethr-did": {
@@ -413,16 +428,24 @@
             "events": "^3.0.0",
             "typeorm": "^0.2.24",
             "uuid": "^7.0.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+              "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+              "dev": true
+            }
           }
         }
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -1012,6 +1035,11 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "number-to-bn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.1.0.tgz",
@@ -1285,9 +1313,9 @@
       }
     },
     "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "which-module": {
       "version": "2.0.0",

--- a/packages/rif-id-daf/package-lock.json
+++ b/packages/rif-id-daf/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-id-daf",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -372,9 +372,9 @@
       }
     },
     "daf-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/daf-core/-/daf-core-6.1.2.tgz",
-      "integrity": "sha512-2uCYhbc2zR/LCk8DY/mc3H/p51K9wCzV15h/icmjqhRVRigoxEpnB+MDcWzwdwfFlbaaHH3ZWOKE3rI4t+WyEg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/daf-core/-/daf-core-6.3.0.tgz",
+      "integrity": "sha512-CZfpGs27OErWMCGTNA3SCBMDvExnAtrHD591iZenusztXKBdLjO/L7Y5y/akoQGH+drTt0WPN7bzpI6/jcx/1A==",
       "requires": {
         "blakejs": "^1.1.0",
         "debug": "^4.1.1",
@@ -1313,9 +1313,9 @@
       }
     },
     "uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "which-module": {
       "version": "2.0.0",

--- a/packages/rif-id-daf/package-lock.json
+++ b/packages/rif-id-daf/package-lock.json
@@ -113,6 +113,14 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-plugin-module-resolver": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
@@ -839,6 +847,11 @@
       "requires": {
         "locate-path": "^2.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/packages/rif-id-daf/package.json
+++ b/packages/rif-id-daf/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@rsksmart/rif-id-ethr-did": "0.0.2",
     "@rsksmart/rif-id-mnemonic": "0.0.1",
+    "axios": "^0.20.0",
     "cross-fetch": "^3.0.6",
     "daf-core": "^6.3.0",
     "daf-ethr-did": "^6.1.2",

--- a/packages/rif-id-daf/package.json
+++ b/packages/rif-id-daf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-id-daf",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "RIF Identity - DAF",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -25,9 +25,12 @@
   "dependencies": {
     "@rsksmart/rif-id-ethr-did": "0.0.2",
     "@rsksmart/rif-id-mnemonic": "0.0.1",
+    "cross-fetch": "^3.0.6",
     "daf-core": "^6.1.2",
     "daf-ethr-did": "^6.1.2",
-    "typeorm": "0.2.24"
+    "debug": "^4.2.0",
+    "typeorm": "0.2.24",
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "daf-libsodium": "^6.1.2"

--- a/packages/rif-id-daf/package.json
+++ b/packages/rif-id-daf/package.json
@@ -26,11 +26,11 @@
     "@rsksmart/rif-id-ethr-did": "0.0.2",
     "@rsksmart/rif-id-mnemonic": "0.0.1",
     "cross-fetch": "^3.0.6",
-    "daf-core": "^6.1.2",
+    "daf-core": "^6.3.0",
     "daf-ethr-did": "^6.1.2",
     "debug": "^4.2.0",
     "typeorm": "0.2.24",
-    "uuid": "^8.3.0"
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "daf-libsodium": "^6.1.2"

--- a/packages/rif-id-daf/src/did-comm-action-handler.ts
+++ b/packages/rif-id-daf/src/did-comm-action-handler.ts
@@ -1,0 +1,92 @@
+import 'cross-fetch/polyfill'
+import { Agent, AbstractActionHandler, Action, Message } from 'daf-core'
+import uuid from 'uuid'
+import Debug from 'debug'
+
+const debug = Debug('daf:did-comm:action-handler')
+
+export const ActionTypes = {
+  sendMessageDIDCommAlpha1: 'send.message.didcomm-alpha-1',
+}
+
+// this module is exported from this package and includes
+// https://github.com/uport-project/daf/pull/239
+
+export interface ActionSendDIDComm extends Action {
+  url?: string
+  save?: boolean
+  data: {
+    id?: string
+    from: string
+    to: string
+    type: string
+    body: any
+  }
+  headers?: HeadersInit
+}
+
+export class DIDCommActionHandler extends AbstractActionHandler {
+  constructor() {
+    super()
+  }
+
+  public async handleAction(action: Action, agent: Agent) {
+    if (action.type === ActionTypes.sendMessageDIDCommAlpha1) {
+      const { data, url, headers, save = true } = action as ActionSendDIDComm
+
+      debug('Resolving didDoc')
+      const didDoc = await agent.didResolver.resolve(data.to)
+      let serviceEndpoint
+      if (url) {
+        serviceEndpoint = url
+      } else {
+        const service = didDoc && didDoc.service && didDoc.service.find(item => item.type == 'Messaging')
+        serviceEndpoint = service?.serviceEndpoint
+      }
+
+      if (serviceEndpoint) {
+        try {
+          data.id = data.id || uuid.v4()
+          let postPayload = JSON.stringify(data)
+          try {
+            const identity = await agent.identityManager.getIdentity(data.from)
+            const key = await identity.keyByType('Ed25519')
+            const publicKey = didDoc?.publicKey.find(item => item.type == 'Ed25519VerificationKey2018')
+            if (!publicKey?.publicKeyHex) throw Error('Recipient does not have encryption publicKey')
+
+            postPayload = await key.encrypt(
+              {
+                type: 'Ed25519',
+                publicKeyHex: publicKey?.publicKeyHex,
+                kid: publicKey?.publicKeyHex,
+              },
+              postPayload,
+            )
+
+            debug('Encrypted:', postPayload)
+          } catch (e) {}
+
+          debug('Sending to %s', serviceEndpoint)
+          const res = await fetch(serviceEndpoint, {
+            method: 'POST',
+            body: postPayload,
+            headers,
+          })
+          debug('Status', res.status, res.statusText)
+
+          if (res.status == 200) {
+            return agent.handleMessage({ raw: data.body, metaData: [{ type: 'DIDComm-sent' }], save })
+          }
+
+          return res.status == 200
+        } catch (e) {
+          return Promise.reject(e)
+        }
+      } else {
+        debug('No Messaging service in didDoc')
+        return super.handleAction(action, agent)
+      }
+    }
+    return super.handleAction(action, agent)
+  }
+}

--- a/packages/rif-id-daf/src/did-comm-action-handler.ts
+++ b/packages/rif-id-daf/src/did-comm-action-handler.ts
@@ -2,6 +2,7 @@ import 'cross-fetch/polyfill'
 import { Agent, AbstractActionHandler, Action, Message } from 'daf-core'
 import uuid from 'uuid'
 import Debug from 'debug'
+import axios from 'axios'
 
 const debug = Debug('daf:did-comm:action-handler')
 
@@ -67,11 +68,7 @@ export class DIDCommActionHandler extends AbstractActionHandler {
           } catch (e) {}
 
           debug('Sending to %s', serviceEndpoint)
-          const res = await fetch(serviceEndpoint, {
-            method: 'POST',
-            body: postPayload,
-            headers,
-          })
+          const res = await axios.post(serviceEndpoint, postPayload, { headers })
           debug('Status', res.status, res.statusText)
 
           if (res.status == 200) {


### PR DESCRIPTION
Enable to use HTTPS headers when issuing credential requests

> This PR introduces a copy of `daf-did-comm` - Reference: https://github.com/uport-project/daf/pull/239