### PR TITLE
Allow custom login message header when signing the challenge

### DIFF
--- a/packages/express-did-auth/package-lock.json
+++ b/packages/express-did-auth/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/express-did-auth",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,6 +16,132 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "@rsksmart/ethr-did": {
+      "version": "1.1.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@rsksmart/ethr-did/-/ethr-did-1.1.1-beta.1.tgz",
+      "integrity": "sha512-7XUR0Xagxc1q9a6z+7Suo8Grno5vZVlkcS04pPO15wgBQ+O4JDaRIAOlxg3fpSFJiiOMxQyIgEEbph9dqJRBuw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "buffer": "^5.4.3",
+        "did-jwt": "^3.0.0",
+        "did-resolver": "^1.0.0",
+        "ethjs-contract": "^0.1.9",
+        "ethjs-provider-http": "^0.1.6",
+        "ethjs-query": "^0.3.8",
+        "ethr-did-resolver": "^1.0.2"
+      },
+      "dependencies": {
+        "@stablelib/utf8": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-0.10.1.tgz",
+          "integrity": "sha512-+uM1YZ4MhBC82vt99prF7DXNGqhYmJ9cQ3p5qNowMNkkzn9OWEkqBvguBW3ChAt7JvqZ3SD5HJOfc6YgnfMTHw==",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "did-jwt": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-3.0.0.tgz",
+          "integrity": "sha512-/zHwoUN6eA+zTpV4HjTVMrVXOGfcfh8le4s9ibvv53ammMwdPj3RnLpw539JtnHm7dCXLq7rpjBkoX3lbbxoPQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@stablelib/utf8": "^0.10.1",
+            "buffer": "^5.2.1",
+            "did-resolver": "^1.0.0",
+            "elliptic": "^6.4.0",
+            "js-sha256": "^0.9.0",
+            "js-sha3": "^0.8.0",
+            "tweetnacl": "^1.0.1",
+            "uport-base64url": "3.0.2-alpha.0"
+          }
+        },
+        "did-resolver": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
+          "integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA==",
+          "dev": true
+        },
+        "ethjs-abi": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
+          "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "js-sha3": "0.5.5",
+            "number-to-bn": "1.7.0"
+          },
+          "dependencies": {
+            "js-sha3": {
+              "version": "0.5.5",
+              "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+              "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+              "dev": true
+            }
+          }
+        },
+        "ethr-did-resolver": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-1.0.3.tgz",
+          "integrity": "sha512-9XtaB+4Ozc4W0gWHZ4J2HA+c+M7r0xcktmQI6v3GMjFto7b42Mq9zhh24kAxCqmtkqQhmUDJeqqSOIOwHrNbmQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.1.0",
+            "did-resolver": "1.0.0",
+            "ethjs-abi": "^0.2.1",
+            "ethjs-contract": "^0.1.9",
+            "ethjs-provider-http": "^0.1.6",
+            "ethjs-query": "^0.3.5",
+            "ethr-did-registry": "^0.0.3"
+          },
+          "dependencies": {
+            "did-resolver": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.0.0.tgz",
+              "integrity": "sha512-mgJG0oqlkG7jfRzW0yN9qKawp24M4thGFdfIaZI30SAJXhpkkjqbkRxqMZLJNwqXEM0cqFbXaiFDqnd9Q1UUaw==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "@rsksmart/rif-id-ethr-did": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-ethr-did/-/rif-id-ethr-did-0.1.0.tgz",
+      "integrity": "sha512-MzU8x4URq3pgMqC43dTo5BrX4EXG+Ue0qbsjvsJlWJafHGegFqNpj3gPRqG5hUZvUmdUe+FuBIbEjG0Aga5JuA==",
+      "dev": true,
+      "requires": {
+        "@rsksmart/ethr-did": "^1.1.1-beta.1",
+        "@types/elliptic": "^6.4.12",
+        "@types/keccak": "^3.0.1",
+        "@types/lodash": "^4.14.157",
+        "@types/node": "^14.0.23",
+        "elliptic": "^6.5.3",
+        "keccak": "^3.0.0",
+        "lodash": "^4.17.19",
+        "rskjs-util": "^1.0.3"
+      }
+    },
+    "@rsksmart/rif-id-mnemonic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-id-mnemonic/-/rif-id-mnemonic-0.1.0.tgz",
+      "integrity": "sha512-8zXs6GPMj/wiUR8NLHFlOLJFy2KVYYZAYxbtvw577DnPlQUhqfEZDFyxx2U6BpCM/vi2eBM1dQ2hQ4IMTeEn4g==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "^4.14.155",
+        "@types/randombytes": "^2.0.0",
+        "bip32": "^2.0.5",
+        "bip39": "^3.0.2",
+        "lodash": "^4.17.15",
+        "randombytes": "^2.1.0"
+      }
     },
     "@sqltools/formatter": {
       "version": "1.2.2",
@@ -223,6 +349,15 @@
         "@types/express-serve-static-core": "*"
       }
     },
+    "@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
@@ -243,6 +378,21 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-/MxAVmtyyeOvZ6dGf3ciLwFRuV5M8DRIyYNFGHYI6UyBW4/XqyO0LZw+JFMvaeY3cHItQAkELclBU1x5ank6mg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.3",
@@ -272,6 +422,15 @@
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
       "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+    },
+    "@types/randombytes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.0.tgz",
+      "integrity": "sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -398,6 +557,58 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip32": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
+      "integrity": "sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.1.3",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+          "dev": true
+        }
+      }
+    },
+    "bip39": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.3.tgz",
+      "integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "11.11.6",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+          "dev": true
+        }
+      }
     },
     "blakejs": {
       "version": "1.1.0",
@@ -964,6 +1175,57 @@
         }
       }
     },
+    "ethjs-abi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.0.tgz",
+      "integrity": "sha1-0+LCIQEVIPxJm3FoIDbBT8wvWyU=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+          "dev": true
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
+        }
+      }
+    },
+    "ethjs-contract": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/ethjs-contract/-/ethjs-contract-0.1.9.tgz",
+      "integrity": "sha1-HCdmiWpW1H7B1tZhgpxJzDilUgo=",
+      "dev": true,
+      "requires": {
+        "ethjs-abi": "0.2.0",
+        "ethjs-filter": "0.1.5",
+        "ethjs-util": "0.1.3",
+        "js-sha3": "0.5.5"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
+          "dev": true
+        }
+      }
+    },
+    "ethjs-filter": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ethjs-filter/-/ethjs-filter-0.1.5.tgz",
+      "integrity": "sha1-ARKvYBfCRnfjK4/esg5hlgGbdZg=",
+      "dev": true
+    },
     "ethjs-format": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.2.7.tgz",
@@ -1166,6 +1428,12 @@
       "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.5.0.tgz",
       "integrity": "sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww=="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -1366,6 +1634,12 @@
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "dev": true
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -1396,6 +1670,12 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -1492,6 +1772,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.2",
@@ -1719,6 +2005,29 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
+    },
+    "rskjs-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rskjs-util/-/rskjs-util-1.0.3.tgz",
+      "integrity": "sha512-Q6zfYFQndaBln1iY2gnBfYgDLymbZHAxKXOcZVLAKJkHilcieoUN3ZXVxLA3K30KlgAfmRVG72iTzi+yPNZB1w==",
+      "dev": true,
+      "requires": {
+        "keccak": "^1.0.2"
+      },
+      "dependencies": {
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -1956,6 +2265,19 @@
         "thenify": ">= 3.1.0 < 4"
       }
     },
+    "tiny-secp256k1": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -1971,6 +2293,12 @@
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
+    "tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true
+    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1979,6 +2307,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+      "dev": true
     },
     "typeorm": {
       "version": "0.2.28",
@@ -2040,6 +2374,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "uport-base64url": {
+      "version": "3.0.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/uport-base64url/-/uport-base64url-3.0.2-alpha.0.tgz",
+      "integrity": "sha512-pRu0xm1K39IUzuMQEmFWdqP+H8jOzblwTXf0r9wFBCa6ZLLQsNuDeUwB2Ld+9zlBSvQQv+XEzG7cQukSCueZqw==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2069,6 +2412,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "dev": true,
+      "requires": {
+        "bs58check": "<3.0.0"
+      }
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/packages/express-did-auth/src/factories/authentication-factory.ts
+++ b/packages/express-did-auth/src/factories/authentication-factory.ts
@@ -23,7 +23,7 @@ export function authenticationFactory (
 
       const { sig, did } = response
 
-      const expectedMessage = `Login to ${config.serviceUrl}\nVerification code: ${challengeVerifier.get(did)}`
+      const expectedMessage = `${config.loginMessageHeader}\nURL: ${config.serviceUrl}\nVerification code: ${challengeVerifier.get(did)}`
 
       const messageDigest = hashPersonalMessage(Buffer.from(expectedMessage))
       const ecdsaSignature = fromRpcSig(sig)

--- a/packages/express-did-auth/src/types.ts
+++ b/packages/express-did-auth/src/types.ts
@@ -40,6 +40,7 @@ export interface ExpressDidAuthConfig extends SignupConfig {
   challengeExpirationTimeInSeconds?: number
   challengeSecret: string
   accessTokenExpirationTimeInSeconds?: number
+  loginMessageHeader?: string
   authenticationBusinessLogic?: AuthenticationBusinessLogic
   maxRequestsPerTimeSlot?: number
   timeSlotInSeconds?: number
@@ -83,4 +84,5 @@ export type SignupBusinessLogic = (payload: SignupChallengeResponsePayload) => P
 
 export interface AuthenticationConfig extends TokenConfig {
   accessTokenExpirationTime?: number
+  loginMessageHeader?: string
 }

--- a/packages/express-did-auth/test/authentication-factory.test.ts
+++ b/packages/express-did-auth/test/authentication-factory.test.ts
@@ -6,12 +6,12 @@ import {
 } from './utils'
 import MockDate from 'mockdate'
 import { INVALID_CHALLENGE_RESPONSE, NO_RESPONSE, UNAUTHORIZED_USER } from '../src/errors'
-import { AppState, AuthenticationBusinessLogic, SelectiveDisclosureResponse, SignupBusinessLogic, SignupChallengeResponsePayload, TokenConfig } from '../src/types'
+import { AppState, AuthenticationBusinessLogic, AuthenticationConfig, SelectiveDisclosureResponse, SignupBusinessLogic, SignupChallengeResponsePayload } from '../src/types'
 import { RequestCounter, RequestCounterConfig, RequestCounterFactory } from '../src/classes/request-counter'
 import { SessionManager, SessionManagerFactory, UserSessionConfig } from '../src/classes/session-manager'
 
 describe('authenticationFactory', () => {
-  let config: TokenConfig
+  let config: AuthenticationConfig
   let userIdentity: Identity
   let userPrivateKey: string
   let state: AppState
@@ -33,7 +33,8 @@ describe('authenticationFactory', () => {
     config = {
       serviceDid: serviceIdentity.did,
       serviceSigner: serviceIdentity.signer,
-      serviceUrl: 'https://the.service.com'
+      serviceUrl: 'https://the.service.com',
+      loginMessageHeader: 'This is the login message header:'
     }
 
     const { identity, privateKey } = identityFactory()
@@ -83,6 +84,22 @@ describe('authenticationFactory', () => {
     await testAuthFactory(state, logic)(req, res)
   })
 
+  test('should respond with 401 if the challenge is signed with another header', async () => {
+    MockDate.set(modulo0Timestamp)
+
+    const challenge = challengeVerifier.get(userIdentity.did)
+    const anotherIdentity = await identityFactory()
+
+    const challengeResponseJwt = challengeResponseFactory(challenge, anotherIdentity.identity, anotherIdentity.privateKey, 'https://taringa.net', 'Another header')
+    challengeResponseJwt.did = userIdentity.did
+
+    const req = { body: { response: challengeResponseJwt } }
+    const res = mockedResFactory(401, INVALID_CHALLENGE_RESPONSE)
+
+    const logic = mockBusinessLogicFactory(false)
+    await testAuthFactory(state, logic)(req, res)
+  })
+
   test('should respond with 401 if the signer of the message is not the specified did', async () => {
     MockDate.set(modulo0Timestamp)
 
@@ -102,7 +119,6 @@ describe('authenticationFactory', () => {
   test('should respond with 401 if invalid challenge', async () => {
     MockDate.set(modulo0Timestamp)
 
-    const challenge = challengeVerifier.get(userIdentity.did)
     const challengeResponseJwt = challengeResponseFactory('a challenge', userIdentity, userPrivateKey, config.serviceUrl)
 
     const req = { body: { response: challengeResponseJwt } }
@@ -116,7 +132,7 @@ describe('authenticationFactory', () => {
     MockDate.set(modulo0Timestamp)
 
     const challenge = challengeVerifier.get(userIdentity.did)
-    const challengeResponseJwt = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl)
+    const challengeResponseJwt = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl, config.loginMessageHeader)
 
     const req = { body: { response: challengeResponseJwt } }
     const res = mockedResFactory(401, UNAUTHORIZED_USER)
@@ -129,7 +145,7 @@ describe('authenticationFactory', () => {
     MockDate.set(modulo0Timestamp)
 
     const challenge = challengeVerifier.get(userIdentity.did)
-    const challengeResponseJwt = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl)
+    const challengeResponseJwt = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl, config.loginMessageHeader)
 
     const errorMessage = 'This is an error'
     const req = { body: { response: challengeResponseJwt } }
@@ -145,19 +161,19 @@ describe('authenticationFactory', () => {
     const challenge = challengeVerifier.get(userIdentity.did)
     const sd: SelectiveDisclosureResponse = {
       credentials: {
-        'Email': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRW1haWwiXSwiY3JlZGVudGlhbFNjaGVtYSI6eyJpZCI6ImRpZDpldGhyOnJzazoweDhhMzJkYTYyNGRkOWZhZDhiZjRmMzJkOTQ1NmYzNzRiNjBkOWFkMjg7aWQ9MWViMmFmNmItMGRlZS02MDkwLWNiNTUtMGVkMDkzZjliMDI2O3ZlcnNpb249MS4wIiwidHlwZSI6Ikpzb25TY2hlbWFWYWxpZGF0b3IyMDE4In0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImVtYWlsQWRkcmVzcyI6ImlsYW5AaW92cHVicy5vcmcifX0sInN1YiI6ImRpZDpldGhyOnJzazp0ZXN0bmV0OjB4OTQ1YjU5ZDVhODZlMmM3ZDUxZjk2MWY0OTg3ZThiMGNhZDRhNGY1NyIsImlzcyI6ImRpZDpldGhyOnJzazoweDcwMDljZGNiZTQxZGQ2MmRkN2U2Y2NmZDhiNzY4OTMyMDdmYmJhNjgifQ.BFd13fjWVGRFYjRDqLuFhtr3xR2kz6CowKOxtWu06m8h_LVcTDTn0A-2VUQo9AsSBjXt7VSRkNeitRrv6lOq3Q'
+        Email: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRW1haWwiXSwiY3JlZGVudGlhbFNjaGVtYSI6eyJpZCI6ImRpZDpldGhyOnJzazoweDhhMzJkYTYyNGRkOWZhZDhiZjRmMzJkOTQ1NmYzNzRiNjBkOWFkMjg7aWQ9MWViMmFmNmItMGRlZS02MDkwLWNiNTUtMGVkMDkzZjliMDI2O3ZlcnNpb249MS4wIiwidHlwZSI6Ikpzb25TY2hlbWFWYWxpZGF0b3IyMDE4In0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImVtYWlsQWRkcmVzcyI6ImlsYW5AaW92cHVicy5vcmcifX0sInN1YiI6ImRpZDpldGhyOnJzazp0ZXN0bmV0OjB4OTQ1YjU5ZDVhODZlMmM3ZDUxZjk2MWY0OTg3ZThiMGNhZDRhNGY1NyIsImlzcyI6ImRpZDpldGhyOnJzazoweDcwMDljZGNiZTQxZGQ2MmRkN2U2Y2NmZDhiNzY4OTMyMDdmYmJhNjgifQ.BFd13fjWVGRFYjRDqLuFhtr3xR2kz6CowKOxtWu06m8h_LVcTDTn0A-2VUQo9AsSBjXt7VSRkNeitRrv6lOq3Q'
       },
       claims: {
-        'Name': 'John Lennon'
+        Name: 'John Lennon'
       }
     }
-    const challengeResponseJwt = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl, sd)
+    const challengeResponseJwt = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl, config.loginMessageHeader, sd)
 
     const req = { body: { response: challengeResponseJwt } }
     const res = mockedResFactory(200, undefined)
 
     const logic = (receivedSd: SignupChallengeResponsePayload) => {
-      expect(receivedSd.sd).toEqual(sd);
+      expect(receivedSd.sd).toEqual(sd)
       return Promise.resolve(true)
     }
 
@@ -171,7 +187,7 @@ describe('authenticationFactory', () => {
       MockDate.set(modulo0Timestamp)
 
       const challenge = challengeVerifier.get(userIdentity.did)
-      const response = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl)
+      const response = challengeResponseFactory(challenge, userIdentity, userPrivateKey, config.serviceUrl, config.loginMessageHeader)
       req = { body: { response } }
 
       const expectedAssertion = (response: MockedResponse) => {

--- a/packages/express-did-auth/test/utils.ts
+++ b/packages/express-did-auth/test/utils.ts
@@ -52,9 +52,10 @@ export const challengeResponseFactory = (
   issuer: Identity,
   issuerPrivateKey: string,
   serviceUrl: string,
+  loginHeaderMessage?: string,
   sd?: SelectiveDisclosureResponse
 ): ChallengeResponse => {
-  let message = `Login to ${serviceUrl}\nVerification code: ${challenge}`
+  const message = `${loginHeaderMessage}\nURL: ${serviceUrl}\nVerification code: ${challenge}`
   const messageDigest = hashPersonalMessage(Buffer.from(message))
 
   const ecdsaSignature = ecsign(


### PR DESCRIPTION
Introduces a new optional config called `loginMessageHeader` that will be used to build the message that is signed in the login process.
Currently it is:
```
Login to SERVICE_URL
Verification code: RECEIVED_CHALLENGE
```

With this new approach, it will be:
```
CUSTOM_MESSAGE_HEADER
URL: SERVICE_URL
Verification code: RECEIVED_CHALLENGE
```

It also fixes some linting issues